### PR TITLE
fix(node): remove build command from tasks.json

### DIFF
--- a/node/.codesandbox/tasks.json
+++ b/node/.codesandbox/tasks.json
@@ -13,11 +13,6 @@
       "name": "start",
       "command": "yarn start",
       "runAtStart": true
-    },
-    "build": {
-      "name": "build",
-      "command": "yarn build",
-      "runAtStart": false
     }
   }
 }


### PR DESCRIPTION
This PR removes a invalid task `build` configured in `node` template in `tasks.json`. 