### PR TITLE
Bun hot reload

### DIFF
--- a/bun/.codesandbox/tasks.json
+++ b/bun/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
   "tasks": {
     "Start": {
       "name": "Start",
-      "command": "bun run http.ts",
+      "command": "bun --hot run http.ts",
       "runAtStart": true
     }
   }


### PR DESCRIPTION
While it's not making the preview browser auto-refresh, it does refresh the code in the webserver for the next [manual] fetch, without needed to restart bun.