### PR TITLE
refactor: move node images to ghcr.io/codesandbox/devcontainers/typescript-node:latest

### DIFF
--- a/angular/.devcontainer/Dockerfile
+++ b/angular/.devcontainer/Dockerfile
@@ -1,3 +1,0 @@
-FROM node:20-bullseye
-
-RUN npm install -g @angular/cli

--- a/angular/.devcontainer/devcontainer.json
+++ b/angular/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/astro-starlight/.devcontainer/Dockerfile
+++ b/astro-starlight/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/astro-starlight/.devcontainer/devcontainer.json
+++ b/astro-starlight/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/astro-tailwind/.devcontainer/Dockerfile
+++ b/astro-tailwind/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/astro-tailwind/.devcontainer/devcontainer.json
+++ b/astro-tailwind/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/astro/.devcontainer/Dockerfile
+++ b/astro/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/astro/.devcontainer/devcontainer.json
+++ b/astro/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/create-t3-app/.devcontainer/Dockerfile
+++ b/create-t3-app/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20.5-bullseye

--- a/create-t3-app/.devcontainer/devcontainer.json
+++ b/create-t3-app/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/docusaurus/.devcontainer/Dockerfile
+++ b/docusaurus/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/docusaurus/.devcontainer/devcontainer.json
+++ b/docusaurus/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/gatsby/.devcontainer/Dockerfile
+++ b/gatsby/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/gatsby/.devcontainer/devcontainer.json
+++ b/gatsby/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/nextjs-app-router/.devcontainer/Dockerfile
+++ b/nextjs-app-router/.devcontainer/Dockerfile
@@ -1,3 +1,0 @@
-FROM node:20-bullseye
-
-RUN npm i -g pnpm

--- a/nextjs-app-router/.devcontainer/devcontainer.json
+++ b/nextjs-app-router/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/nextjs/.devcontainer/Dockerfile
+++ b/nextjs/.devcontainer/Dockerfile
@@ -1,3 +1,0 @@
-FROM node:20-bullseye
-
-# The workspace will be mounted under /workspace

--- a/nextjs/.devcontainer/devcontainer.json
+++ b/nextjs/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/node-http-server/.devcontainer/Dockerfile
+++ b/node-http-server/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/node-http-server/.devcontainer/devcontainer.json
+++ b/node-http-server/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/node/.devcontainer/Dockerfile
+++ b/node/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/node/.devcontainer/devcontainer.json
+++ b/node/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/nodebox-starter/.devcontainer/Dockerfile
+++ b/nodebox-starter/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/nodebox-starter/.devcontainer/devcontainer.json
+++ b/nodebox-starter/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/nuxt/.devcontainer/Dockerfile
+++ b/nuxt/.devcontainer/Dockerfile
@@ -1,3 +1,0 @@
-FROM node:20-bullseye
-
-RUN npm i -g pnpm

--- a/nuxt/.devcontainer/devcontainer.json
+++ b/nuxt/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/qwik-vite/.devcontainer/Dockerfile
+++ b/qwik-vite/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/qwik-vite/.devcontainer/devcontainer.json
+++ b/qwik-vite/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/react-native-expo/.devcontainer/Dockerfile
+++ b/react-native-expo/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:21-bullseye

--- a/react-native-expo/.devcontainer/devcontainer.json
+++ b/react-native-expo/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/react-vite-ts/.devcontainer/Dockerfile
+++ b/react-vite-ts/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/react-vite-ts/.devcontainer/devcontainer.json
+++ b/react-vite-ts/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/remix/.devcontainer/Dockerfile
+++ b/remix/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20

--- a/remix/.devcontainer/devcontainer.json
+++ b/remix/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/solid-vite/.devcontainer/Dockerfile
+++ b/solid-vite/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/solid-vite/.devcontainer/devcontainer.json
+++ b/solid-vite/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/sveltekit/.devcontainer/Dockerfile
+++ b/sveltekit/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/sveltekit/.devcontainer/devcontainer.json
+++ b/sveltekit/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/vite-ts/.devcontainer/Dockerfile
+++ b/vite-ts/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/vite-ts/.devcontainer/devcontainer.json
+++ b/vite-ts/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }

--- a/vue-vite/.devcontainer/Dockerfile
+++ b/vue-vite/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:20-bullseye

--- a/vue-vite/.devcontainer/devcontainer.json
+++ b/vue-vite/.devcontainer/devcontainer.json
@@ -1,6 +1,4 @@
 {
   "name": "Devcontainer",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  }
+  "image": "ghcr.io/codesandbox/devcontainers/typescript-node:latest"
 }


### PR DESCRIPTION
This ensures a better cache utilization when starting a template from scratch.