### PR TITLE
remove hibernation and add progress of restart

### DIFF
--- a/.scripts/restart-all-templates.ts
+++ b/.scripts/restart-all-templates.ts
@@ -1,41 +1,34 @@
 import { getSyncedSandboxDetails } from "./api.ts";
-import {
-  hibernateSandbox,
-  shutdownSandbox,
-  startSandbox,
-} from "./pitcher-manager.ts";
+import { shutdownSandbox, startSandbox } from "./pitcher-manager.ts";
 import { getTemplates } from "./utils.ts";
 
-const clusters = [
-  "fc-eu-0",
-  "fc-eu-2",
-  "fc-us-0",
-];
+const clusters = ["fc-eu-0", "fc-eu-2", "fc-us-0"];
 
 const owner = "codesandbox";
 const repo = "sandbox-templates";
 const branch = "main";
 
+let doneCount = 0;
 async function restartTemplate(template: string) {
   const sandboxDetails = await getSyncedSandboxDetails(
     owner,
     repo,
     branch,
-    template,
+    template
   );
   await Promise.all(
     clusters.map(async (clusterName) => {
       console.log(
-        `Restarting sandbox, Cluster:${clusterName} \t SandboxId:${sandboxDetails.id} \t Template: ${template}`,
+        `Restarting sandbox (${doneCount}/${templates.size}), Cluster:${clusterName} \t SandboxId:${sandboxDetails.id} \t Template: ${template}`
       );
 
       // Start sandbox so that shutdown works later (eg: start from hibernation)
       await startSandbox(clusterName, sandboxDetails.id);
       await shutdownSandbox(clusterName, sandboxDetails.id);
       await startSandbox(clusterName, sandboxDetails.id);
-      await hibernateSandbox(clusterName, sandboxDetails.id);
-    }),
+    })
   );
+  doneCount++;
 }
 const templates = await getTemplates();
 


### PR DESCRIPTION
Removed hibernation after restarting a template. The hibernation was happening even before the devcontainer build was done, so resuming/forking from the templates still was in the setup tasks. With this PR we let the templates hibernate after 5mins of inactivity.

Also added a the progress for restart script