### PR TITLE
add gitignore for rust axum template

### DIFF
--- a/rust-axum/.gitignore
+++ b/rust-axum/.gitignore
@@ -1,0 +1,2 @@
+/target
+/.cargo


### PR DESCRIPTION
This PR adds a git ignore to rust axum template to ignore target and .cargo folders