### PR TITLE
fix: order of tags

### DIFF
--- a/astro-tailwind/.codesandbox/template.json
+++ b/astro-tailwind/.codesandbox/template.json
@@ -2,13 +2,6 @@
   "title": "Astro Tailwind Starter",
   "description": "Astro together with Tailwind on CodeSandbox",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/astro-tailwind/.codesandbox/icon.png",
-  "tags": [
-    "astro",
-    "javascript",
-    "typescript",
-    "tailwind",
-    "tailwindcss",
-    "starter"
-  ],
+  "tags": ["starter", "astro", "javascript", "typescript", "tailwind"],
   "published": true
 }

--- a/cloudflare-worker/.codesandbox/template.json
+++ b/cloudflare-worker/.codesandbox/template.json
@@ -2,6 +2,6 @@
 	"title": "Cloudflare Workers (Simple)",
 	"description": "A Cloudflare worker template that outputs a simple \"Hello World\"",
 	"iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/cloudflare-worker/.codesandbox/icon.png",
-	"tags": ["cloudflare", "cloudflare workers", "edge", "javascript", "typescript", "backend"],
+	"tags": ["backend", "cloudflare", "cloudflare workers", "edge", "javascript", "typescript"],
 	"published": true
 }

--- a/create-t3-app/.codesandbox/template.json
+++ b/create-t3-app/.codesandbox/template.json
@@ -3,6 +3,7 @@
   "description": "This is a [T3 Stack](https://create.t3.gg/) project bootstrapped with `create-t3-app`.",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/create-t3-app/.codesandbox/icon.png",
   "tags": [
+    "starter",
     "javascript",
     "typescript",
     "t3",
@@ -10,8 +11,7 @@
     "react",
     "nextjs",
     "tailwindcss",
-    "trpc",
-    "starter"
+    "trpc"
   ],
   "published": true
 }

--- a/jupyter/.codesandbox/template.json
+++ b/jupyter/.codesandbox/template.json
@@ -2,6 +2,6 @@
   "title": "Jupyter",
   "description": "This is a starter for Jupyter Notebook or Lab. Jupyter is the latest web-based interactive development environment for notebooks, code, and data. Its flexible interface allows users to configure and arrange workflows in data science, scientific computing, computational journalism, and machine learning.",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/jupyter/.codesandbox/icon.png",
-  "tags": ["python", "pip", "jupyter", "ai", "machine learning", "starter"],
+  "tags": ["starter", "python", "pip", "jupyter", "ai", "machine learning"],
   "published": true
 }

--- a/nextjs-app-router/.codesandbox/template.json
+++ b/nextjs-app-router/.codesandbox/template.json
@@ -3,12 +3,12 @@
   "description": "This is a Next.js project using Next.js 13 `/app` directory.",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/nextjs-app-router/.codesandbox/icon.png",
   "tags": [
+    "starter",
     "nextjs",
     "javascript",
     "typescript",
     "react",
-    "app-router",
-    "starter"
+    "app-router"
   ],
   "published": true
 }

--- a/nextjs/.codesandbox/template.json
+++ b/nextjs/.codesandbox/template.json
@@ -3,12 +3,12 @@
   "description": "The official Next.js template by the CodeSandbox team",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/nextjs/.codesandbox/icon.png",
   "tags": [
-    "nextjs",
-    "javascript",
-    "typescript",
-    "react",
     "featured",
-    "frontend"
+    "frontend",
+    "nextjs",
+    "react",
+    "javascript",
+    "typescript"
   ],
   "published": true
 }

--- a/nuxt-todos-edge/.codesandbox/template.json
+++ b/nuxt-todos-edge/.codesandbox/template.json
@@ -3,13 +3,13 @@
   "description": "Perfect starter for building a Nuxt.js application for the edge with Drizzle and SQLite",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/nuxt/.codesandbox/icon.png",
   "tags": [
+    "starter",
     "javascript",
     "typescript",
     "vue",
     "nuxt",
     "drizzle",
-    "sqlite",
-    "starter"
+    "sqlite"
   ],
   "published": true
 }

--- a/postgres-drizzle-nextjs/.codesandbox/template.json
+++ b/postgres-drizzle-nextjs/.codesandbox/template.json
@@ -3,14 +3,14 @@
   "description": "The perfect starter for a full-stack application using Next.js, Postgres and Drizzle-ORM.",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/nextjs/.codesandbox/icon.png",
   "tags": [
+    "featured",
+    "starter",
     "nextjs",
     "javascript",
     "typescript",
     "react",
     "postgres",
-    "drizzle-orm",
-    "featured",
-    "starter"
+    "drizzle-orm"
   ],
   "published": true
 }

--- a/react-vite-ts/.codesandbox/template.json
+++ b/react-vite-ts/.codesandbox/template.json
@@ -2,6 +2,6 @@
   "title": "React (Vite + TS)",
   "description": "React running from the Vite dev server!",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/react-vite-ts/.codesandbox/icon.png",
-  "tags": ["react", "vite", "javascript", "typescript", "featured", "frontend"],
+  "tags": ["featured", "frontend", "react", "vite", "javascript", "typescript"],
   "published": true
 }

--- a/remix/.codesandbox/template.json
+++ b/remix/.codesandbox/template.json
@@ -2,6 +2,6 @@
   "title": "Remix",
   "description": "The official Remix Cloud Sandbox Template by the CodeSandbox team",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/remix/.codesandbox/icon.png",
-  "tags": ["react", "remix", "javascript", "typescript", "frontend", "starter"],
+  "tags": ["frontend", "starter", "react", "remix", "javascript", "typescript"],
   "published": true
 }

--- a/storybook-react/.codesandbox/template.json
+++ b/storybook-react/.codesandbox/template.json
@@ -2,6 +2,6 @@
   "title": "Storybook (React)",
   "description": "An example of running Storybook on CodeSandbox",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/storybook-react/.codesandbox/icon.png",
-  "tags": ["react", "storybook", "vite", "javascript", "typescript", "starter"],
+  "tags": ["starter", "react", "storybook", "vite", "javascript", "typescript"],
   "published": true
 }

--- a/sveltekit/.codesandbox/template.json
+++ b/sveltekit/.codesandbox/template.json
@@ -3,11 +3,12 @@
   "description": "The official Svelte Cloud Sandbox Template by the CodeSandbox team",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/sveltekit/.codesandbox/icon.png",
   "tags": [
+    "frontend", 
+    "starter",
     "svelekit",
     "svelekit",
     "javascript",
-    "typescript",
-    "frontend", "starter"
+    "typescript"
   ],
   "published": true
 }

--- a/vue-vite/.codesandbox/template.json
+++ b/vue-vite/.codesandbox/template.json
@@ -3,13 +3,13 @@
   "description": "Vue 3 set up using Vite",
   "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/vue-vite/.codesandbox/icon.png",
   "tags": [
+    "featured",
+    "frontend",
     "vue",
     "vue3",
     "vite",
     "javascript",
-    "typescript",
-    "featured",
-    "frontend"
+    "typescript"
   ],
   "published": true
 }


### PR DESCRIPTION
Ok, this is a bit silly, but wanted to quickly fix the tags problem. It seems that still only the first 5 are compiled into the main `templates.json` file, @CompuIves made a change on the backend last week but it doesn't yet work?

As a quick fix, I changed the order for the tags we care most about on the client, so I can wrap up the create modals