### PR TITLE
chore: ensure that all templates restart from time to time

### DIFF
--- a/.github/workflows/restart-template.yaml
+++ b/.github/workflows/restart-template.yaml
@@ -1,10 +1,13 @@
 name: Restart Template
 
 on:
+  schedule:
+    # Restart every template every 3 days, to ensure that the snapshot remains
+    - cron: "0 07 */3 * *"
   workflow_dispatch:
     inputs:
       template:
-        description: 'Enter the folder name for the template (empty to restart all templates)'
+        description: "Enter the folder name for the template (empty to restart all templates)"
         required: false
         type: string
 
@@ -16,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout head
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 2
+      - name: Checkout head
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
-    - name: Setup Deno
-      uses: denoland/setup-deno@v1
-      with:
-        deno-version: v1.x
-      
-    - name: Run Deno Script
-      run: deno run --allow-read --allow-net --allow-write --allow-env --unstable --allow-run .scripts/restart-all-templates.ts ${{ inputs.template }}
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Run Deno Script
+        run: deno run --allow-read --allow-net --allow-write --allow-env --unstable --allow-run .scripts/restart-all-templates.ts ${{ inputs.template }}

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ We have 4 official Sandbox templates:
 
 - **[React](https://codesandbox.io/p/sandbox/react-new)**
 - **[React Typescript](https://codesandbox.io/p/sandbox/react-typescript-react-ts)**
-- **[Vanilla Typescript](https://codesandbox.io/p/sandbox/vanilla-typescript-vanilla-ts
-)**
+- **[Vanilla Typescript](https://codesandbox.io/p/sandbox/vanilla-typescript-vanilla-ts)**
 - **HTML + CSS** ([GitHub](https://github.com/codesandbox-app/static-template))
 
 When converting a Sandbox to a Devbox we use the [Sandbox Migration](./sandbox-migration/) template, which has all dependencies of our Sandbox templates installed.


### PR DESCRIPTION
This ensures that we always have snapshots available for all templates