### PR TITLE
nodejs-sandbox: Switch `nodemon` to `node --watch`

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -4,13 +4,11 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon index.js"
+    "start": "node --watch index.js"
   },
   "keywords": [],
   "author": "Ives van Hoorne",
   "license": "MIT",
-  "devDependencies": {
-    "nodemon": "^3.0.1"
-  },
+  "devDependencies": {},
   "dependencies": {}
 }


### PR DESCRIPTION
Switch `nodemon` to built-in [`node --watch`](https://nodejs.org/docs/v20.16.0/api/cli.html#--watch)

There is an experimental warning the first time that you run the `npm start` script, but it [has become stable in Node.js v20.13.0](https://nodejs.org/en/blog/release/v20.13.0#watch-mark-as-stable), which is the minor release directly following the Node.js v20.12.0 version which is on CodeSandbox.


Sandbox: https://codesandbox.io/p/devbox/switch-nodemon-to-node--watch-cfh88s?file=%2Findex.js%3A1%2C32

```bash
 npm start            

> nodejs-sandbox@1.0.0 start
> node --watch index.js

(node:2873) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Hello CodeSandbox
Completed running 'index.js'
```

![Screenshot 2024-07-25 at 09 25 36](https://github.com/user-attachments/assets/4afdc4ba-ac98-44c7-9ca7-b4309eba7f9d)



```bash
Restarting 'index.js'
Hello CodeSandbox2
Completed running 'index.js'
```

![Screenshot 2024-07-25 at 09 20 15](https://github.com/user-attachments/assets/c1eced4f-2a5b-4b16-ac32-93fcf6897630)
